### PR TITLE
Add raw score inputs for Beery tab and custom report naming

### DIFF
--- a/combined.py
+++ b/combined.py
@@ -261,9 +261,23 @@ with tab3:
 with tab4:
     st.subheader("✍️ Enter Beery Scores")
 
-    vmi = st.text_input("Visual-Motor Integration (VMI) Percentile", key="vmi_input")
-    vp = st.text_input("Visual Perception (VP) Percentile", key="vp_input")
-    mc = st.text_input("Motor Coordination (MC) Percentile", key="mc_input")
+    col1, col2 = st.columns(2)
+    with col1:
+        vmi = st.text_input("Visual-Motor Integration (VMI) Percentile", key="vmi_input")
+    with col2:
+        vmi_raw = st.text_input("VMI Raw Score", key="vmi_raw_input")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        vp = st.text_input("Visual Perception (VP) Percentile", key="vp_input")
+    with col2:
+        vp_raw = st.text_input("VP Raw Score", key="vp_raw_input")
+
+    col1, col2 = st.columns(2)
+    with col1:
+        mc = st.text_input("Motor Coordination (MC) Percentile", key="mc_input")
+    with col2:
+        mc_raw = st.text_input("MC Raw Score", key="mc_raw_input")
 
 with tab5:
     if uploaded_doc and uploaded_wisc:
@@ -271,6 +285,12 @@ with tab5:
             "Select WIAT Report Gender Template:",
             ("Male", "Female"),
             key="gender"
+        )
+
+        report_name_input = st.text_input(
+            "Report file name (without .docx)",
+            value="combined_report",
+            key="report_name_input"
         )
 
         if st.button("Generate Combined Report"):
@@ -311,14 +331,20 @@ with tab5:
                 lookup["VMI Percentile"] = vmi
                 lookup["VMI Percentile*"] = format_percentile_with_suffix(vmi)
                 lookup["VMI Classification"] = classify(vmi)
+            if vmi_raw:
+                lookup["VMI Raw Score"] = vmi_raw
             if vp:
                 lookup["VP Percentile"] = vp
                 lookup["VP Percentile*"] = format_percentile_with_suffix(vp)
                 lookup["VP Classification"] = classify(vp)
+            if vp_raw:
+                lookup["VP Raw Score"] = vp_raw
             if mc:
                 lookup["MC Percentile"] = mc
                 lookup["MC Percentile*"] = format_percentile_with_suffix(mc)
                 lookup["MC Classification"] = classify(mc)
+            if mc_raw:
+                lookup["MC Raw Score"] = mc_raw
 
             # === ChAMP
             if not champ_df.empty:
@@ -375,9 +401,13 @@ with tab5:
 
             st.success("✅ Combined document generated successfully!")
 
+            final_name = report_name_input.strip() or "combined_report"
+            if not final_name.lower().endswith(".docx"):
+                final_name += ".docx"
+
             st.download_button(
                 label="📥 Download Combined Report",
                 data=output,
-                file_name="combined_report.docx",
+                file_name=final_name,
                 mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
             )


### PR DESCRIPTION
## Summary
- Add side-by-side raw score fields for VMI, VP, and MC on the Beery tab
- Support new `{{VMI Raw Score}}`, `{{VP Raw Score}}`, and `{{MC Raw Score}}` placeholders
- Allow users to name the generated report on the Finalize tab and apply that name to the download

## Testing
- `python -m py_compile combined.py && echo "py_compile successful"`


------
https://chatgpt.com/codex/tasks/task_e_6893a945552c83309b678ed45716754a