### PR TITLE
Add CEFI PDF extraction tab

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 pandas
 python-docx
 openpyxl
+pdfplumber


### PR DESCRIPTION
## Summary
- add pdfplumber dependency
- add CEFI tab to parse PDF and classify percentiles
- include CEFI results in final report lookup

## Testing
- `python -m py_compile combined.py`
- `pip install pdfplumber` *(failed: Could not find a version that satisfies the requirement pdfplumber (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_6894e174a5c8833087a095078a27bbb0